### PR TITLE
Fix navigation text visibility with dark background

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -51,7 +51,7 @@ const Navigation = () => {
               variant="ghost"
               size="icon"
               onClick={() => setIsOpen(!isOpen)}
-              className="text-foreground"
+              className="text-white"
             >
               {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
             </Button>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -13,13 +13,15 @@ const Navigation = () => {
   ];
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-white/10 backdrop-blur-lg border-b border-white/20">
+    <nav className="fixed top-0 left-0 right-0 z-50 bg-slate-900/80 backdrop-blur-lg border-b border-white/10 text-white shadow-lg">
       <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <div className="flex items-center space-x-2">
             <img src="https://cdn.builder.io/api/v1/image/assets%2Fde743b16560c4ea5a4a46e65a2543876%2F4be0568d99d2469baa7ef6c274a8a1b2?format=webp&width=800" alt="StoriesByFoot logo" className="h-10 w-auto" />
-            <span className="text-xl font-bold text-primary">StoriesByFoot</span>
+            <span className="text-xl font-bold tracking-wide text-white">
+              StoriesBy<span className="text-secondary">Foot</span>
+            </span>
           </div>
 
           {/* Desktop Navigation */}
@@ -28,10 +30,10 @@ const Navigation = () => {
               <a
                 key={item.name}
                 href={item.href}
-                className="text-foreground hover:text-primary transition-colors font-medium relative group"
+                className="text-white/90 hover:text-white transition-colors font-medium relative group"
               >
                 {item.name}
-                <span className="absolute -bottom-1 left-0 w-0 h-0.5 bg-primary transition-all duration-300 group-hover:w-full"></span>
+                <span className="absolute -bottom-1 left-0 w-0 h-0.5 bg-white transition-all duration-300 group-hover:w-full"></span>
               </a>
             ))}
           </div>
@@ -59,12 +61,12 @@ const Navigation = () => {
         {/* Mobile Navigation */}
         {isOpen && (
           <div className="md:hidden">
-            <div className="px-2 pt-2 pb-3 space-y-1 bg-white/95 backdrop-blur-lg rounded-lg mt-2 shadow-card">
+            <div className="px-2 pt-2 pb-3 space-y-1 bg-slate-900/95 border border-white/10 backdrop-blur-lg rounded-lg mt-2 shadow-lg">
               {navItems.map((item) => (
                 <a
                   key={item.name}
                   href={item.href}
-                  className="block px-3 py-2 text-base font-medium text-foreground hover:text-primary hover:bg-primary/5 rounded-md transition-colors"
+                  className="block px-3 py-2 text-base font-medium text-white/90 hover:text-white hover:bg-white/10 rounded-md transition-colors"
                   onClick={() => setIsOpen(false)}
                 >
                   {item.name}


### PR DESCRIPTION
## Purpose
The user reported that the navigation text (StoriesByFoot logo and menu items like Destinations, Services, About, Contact) was not clearly visible against the background color on the website. The text was blending with the background, making it difficult to read unless looked at carefully.

## Code changes
- Changed navigation background from transparent white (`bg-white/10`) to dark slate (`bg-slate-900/80`) for better contrast
- Updated all text colors to white/off-white variants for improved visibility against the dark background
- Modified logo text styling with white color and added accent color for "Foot" part
- Updated navigation links to use white text with hover effects
- Applied consistent white text styling to mobile menu button and mobile navigation items
- Enhanced mobile menu with dark background and white border for better visual separationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0a0b946642f245ebb302ce4184be64f7/zen-forge)

👀 [Preview Link](https://0a0b946642f245ebb302ce4184be64f7-zen-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0a0b946642f245ebb302ce4184be64f7</projectId>-->
<!--<branchName>zen-forge</branchName>-->